### PR TITLE
Update Fhenix-JS.mdx

### DIFF
--- a/docs/devdocs/FhenixJS/Fhenix-JS.mdx
+++ b/docs/devdocs/FhenixJS/Fhenix-JS.mdx
@@ -160,7 +160,7 @@ This example demonstrates a full interaction between a dApp and an FHE-enabled s
 import { FhenixClient } from 'fhenixjs';
 import { JsonRpcProvider } from 'ethers'
 
-const provider = new JsonRpcProvider('https://api.helium.fhenix.zone');
+const provider = new JsonRpcProvider('https://api.nitrogen.fhenix.zone');
 const client = new FhenixClient({provider});
 
 // == Input ==


### PR DESCRIPTION
updating the JsonRpcProvider link to the nitrogen testnet in the End-to-End Example Explanation